### PR TITLE
Akka とアクターモデル 初級課題

### DIFF
--- a/src/main/scala/MessageCountActorApp.scala
+++ b/src/main/scala/MessageCountActorApp.scala
@@ -1,3 +1,29 @@
-object MessageCountActorApp extends App {
 
+
+import akka.actor.{Actor, ActorSystem, Inbox, Props}
+import akka.event.Logging
+
+import scala.concurrent.duration.DurationInt
+
+class MessageCounter extends Actor {
+  val log = Logging(context.system, this)
+  var count: Int = 0
+
+  def receive = {
+    case _ => {
+      count += 1
+      println(s"I have received $count messeages.")
+      if (count >= 10000) {
+        context.system.terminate()
+      }
+    }
+  }
+}
+
+object MessageCountActorApp extends App {
+  val system = ActorSystem("messageCountActorApp")
+
+  val counter = system.actorOf(Props[MessageCounter])
+
+  for (i <- 1 to 10000) counter ! "message"
 }


### PR DESCRIPTION
Actor側で10000回メッセージを表示したら、Actor側からActorSystemをterminateする形で実装。

Actor側でメッセージを順次処理するため、メインスレッド側で非同期処理の終了を待機しなくてもよい。
……この実装だと、メインスレッドのループが10000を越えるとエラーが発生してしまうが。